### PR TITLE
Userdata get

### DIFF
--- a/Backend/models/MealPlan.js
+++ b/Backend/models/MealPlan.js
@@ -5,6 +5,7 @@ const mealPlanSchema = new mongoose.Schema({
   meals: [{
     name: {
       type:String,
+      required:true,
       
     },
     type: { type: String, enum: ['Breakfast', 'Lunch', 'Dinner', 'Snack', 'Post-Workout'] },

--- a/Backend/routes/mealPlans.js
+++ b/Backend/routes/mealPlans.js
@@ -41,6 +41,22 @@ router.put('/:mealPlanId/meals/:mealIndex', async (req, res) => {
 });
 
 
+router.get('/user/:userId', async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const mealPlans = await meal.find({ userId });
+
+    if (!mealPlans || mealPlans.length === 0) {
+      return res.status(404).json({ message: 'No meal plans found for this user' });
+    }
+
+    res.json(mealPlans);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+
 module.exports = router;
 
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add GET endpoint to retrieve meal plans by user ID

- Enforce required field for meal name in meal plan schema


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MealPlan.js</strong><dd><code>Require meal name in meal plan schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/models/MealPlan.js

<li>Added <code>required: true</code> to the <code>name</code> field in the meal schema.<br> <li> Ensures every meal entry must have a name.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S67_Rithanya_Capstone_Foodicine/pull/12/files#diff-8477fcbd30e3f9e8083e755ab67223ab4b59331b0eb705e8fa4a84060b82ea22">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mealPlans.js</strong><dd><code>Add GET endpoint for fetching user's meal plans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/routes/mealPlans.js

<li>Added GET <code>/user/:userId</code> endpoint to fetch meal plans for a user.<br> <li> Returns 404 if no meal plans are found for the user.<br> <li> Handles errors with appropriate status codes and messages.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S67_Rithanya_Capstone_Foodicine/pull/12/files#diff-8de37433f2cda7eef848fe409bcf7424d1bab5a0f030c340ea52b4b7d1e745d9">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>